### PR TITLE
Add authentication endpoints and user update support

### DIFF
--- a/app/Http/Controllers/Auth/LoginController.php
+++ b/app/Http/Controllers/Auth/LoginController.php
@@ -1,0 +1,31 @@
+<?php
+
+namespace App\Http\Controllers\Auth;
+
+use App\Http\Controllers\Controller;
+use App\Http\Requests\Auth\LoginRequest;
+use App\Models\User;
+use Illuminate\Http\JsonResponse;
+use Illuminate\Support\Facades\Hash;
+use Illuminate\Validation\ValidationException;
+
+class LoginController extends Controller
+{
+    public function __invoke(LoginRequest $request): JsonResponse
+    {
+        $credentials = $request->validated();
+
+        $user = User::where('email', $credentials['email'])->first();
+
+        if (! $user || ! Hash::check($credentials['password'], $user->password)) {
+            throw ValidationException::withMessages([
+                'email' => [trans('auth.failed')],
+            ]);
+        }
+
+        return response()->json([
+            'user' => $user,
+            'token' => $user->createToken('auth_token')->plainTextToken,
+        ]);
+    }
+}

--- a/app/Http/Controllers/Auth/LoginController.php
+++ b/app/Http/Controllers/Auth/LoginController.php
@@ -4,6 +4,7 @@ namespace App\Http\Controllers\Auth;
 
 use App\Http\Controllers\Controller;
 use App\Http\Requests\Auth\LoginRequest;
+use App\Http\Resources\UserResource;
 use App\Models\User;
 use Illuminate\Http\JsonResponse;
 use Illuminate\Support\Facades\Hash;
@@ -24,7 +25,7 @@ class LoginController extends Controller
         }
 
         return response()->json([
-            'user' => $user,
+            'user' => new UserResource($user),
             'token' => $user->createToken('auth_token')->plainTextToken,
         ]);
     }

--- a/app/Http/Controllers/Auth/LogoutController.php
+++ b/app/Http/Controllers/Auth/LogoutController.php
@@ -1,0 +1,20 @@
+<?php
+
+namespace App\Http\Controllers\Auth;
+
+use App\Http\Controllers\Controller;
+use Illuminate\Http\Request;
+
+class LogoutController extends Controller
+{
+    public function __invoke(Request $request)
+    {
+        $token = $request->user()?->currentAccessToken();
+
+        if ($token !== null) {
+            $token->delete();
+        }
+
+        return response()->noContent();
+    }
+}

--- a/app/Http/Controllers/Auth/UpdateAuthenticatedUserController.php
+++ b/app/Http/Controllers/Auth/UpdateAuthenticatedUserController.php
@@ -1,0 +1,30 @@
+<?php
+
+namespace App\Http\Controllers\Auth;
+
+use App\Http\Controllers\Controller;
+use App\Http\Requests\Auth\UpdateAuthenticatedUserRequest;
+use App\Http\Resources\UserResource;
+use Illuminate\Http\Resources\Json\JsonResource;
+
+class UpdateAuthenticatedUserController extends Controller
+{
+    public function __invoke(UpdateAuthenticatedUserRequest $request): JsonResource
+    {
+        $user = $request->user();
+
+        $data = collect($request->validated())
+            ->only(['email', 'password'])
+            ->filter(static fn ($value) => $value !== null && $value !== '');
+
+        if ($data->isNotEmpty()) {
+            $user->fill($data->toArray());
+
+            if ($user->isDirty()) {
+                $user->save();
+            }
+        }
+
+        return new UserResource($user->fresh());
+    }
+}

--- a/app/Http/Controllers/Auth/UpdateAuthenticatedUserController.php
+++ b/app/Http/Controllers/Auth/UpdateAuthenticatedUserController.php
@@ -14,11 +14,11 @@ class UpdateAuthenticatedUserController extends Controller
         $user = $request->user();
 
         $data = collect($request->validated())
-            ->only(['email', 'password'])
-            ->filter(static fn ($value) => $value !== null && $value !== '');
+            ->only(['email', 'password', 'image'])
+            ->toArray();
 
-        if ($data->isNotEmpty()) {
-            $user->fill($data->toArray());
+        if (! empty($data)) {
+            $user->fill($data);
 
             if ($user->isDirty()) {
                 $user->save();

--- a/app/Http/Requests/Auth/LoginRequest.php
+++ b/app/Http/Requests/Auth/LoginRequest.php
@@ -1,0 +1,21 @@
+<?php
+
+namespace App\Http\Requests\Auth;
+
+use Illuminate\Foundation\Http\FormRequest;
+
+class LoginRequest extends FormRequest
+{
+    public function authorize(): bool
+    {
+        return true;
+    }
+
+    public function rules(): array
+    {
+        return [
+            'email' => ['required', 'string', 'lowercase', 'email'],
+            'password' => ['required', 'string'],
+        ];
+    }
+}

--- a/app/Http/Requests/Auth/UpdateAuthenticatedUserRequest.php
+++ b/app/Http/Requests/Auth/UpdateAuthenticatedUserRequest.php
@@ -1,0 +1,36 @@
+<?php
+
+namespace App\Http\Requests\Auth;
+
+use Illuminate\Foundation\Http\FormRequest;
+use Illuminate\Validation\Rule;
+use Illuminate\Validation\Rules\Password;
+use Illuminate\Validation\Validator;
+
+class UpdateAuthenticatedUserRequest extends FormRequest
+{
+    public function authorize(): bool
+    {
+        return true;
+    }
+
+    public function rules(): array
+    {
+        return [
+            'email' => ['sometimes', 'required', 'string', 'lowercase', 'email', 'max:255', Rule::unique('users', 'email')->ignore($this->user()?->id)],
+            'password' => ['sometimes', 'required', 'confirmed', Password::defaults()],
+            'name' => ['prohibited'],
+        ];
+    }
+
+    public function after(): array
+    {
+        return [
+            function (Validator $validator): void {
+                if (! $this->filled('email') && ! $this->filled('password')) {
+                    $validator->errors()->add('email', 'Debe proporcionar al menos el correo electrónico o la contraseña.');
+                }
+            },
+        ];
+    }
+}

--- a/app/Http/Requests/Auth/UpdateAuthenticatedUserRequest.php
+++ b/app/Http/Requests/Auth/UpdateAuthenticatedUserRequest.php
@@ -19,6 +19,7 @@ class UpdateAuthenticatedUserRequest extends FormRequest
         return [
             'email' => ['sometimes', 'required', 'string', 'lowercase', 'email', 'max:255', Rule::unique('users', 'email')->ignore($this->user()?->id)],
             'password' => ['sometimes', 'required', 'confirmed', Password::defaults()],
+            'image' => ['sometimes', 'nullable', 'string', 'max:2048'],
             'name' => ['prohibited'],
         ];
     }
@@ -27,8 +28,10 @@ class UpdateAuthenticatedUserRequest extends FormRequest
     {
         return [
             function (Validator $validator): void {
-                if (! $this->filled('email') && ! $this->filled('password')) {
-                    $validator->errors()->add('email', 'Debe proporcionar al menos el correo electrónico o la contraseña.');
+                $hasImage = $this->has('image');
+
+                if (! $this->filled('email') && ! $this->filled('password') && ! $hasImage) {
+                    $validator->errors()->add('email', 'Debe proporcionar al menos el correo electrónico, la contraseña o la imagen.');
                 }
             },
         ];

--- a/app/Http/Resources/UserResource.php
+++ b/app/Http/Resources/UserResource.php
@@ -17,6 +17,7 @@ class UserResource extends JsonResource
             'name' => $this->name,
             'email' => $this->email,
             'username' => $this->username,
+            'image' => $this->image,
             'created_at' => $this->created_at?->toIso8601String(),
             'updated_at' => $this->updated_at?->toIso8601String(),
         ];

--- a/app/Models/User.php
+++ b/app/Models/User.php
@@ -16,6 +16,7 @@ class User extends Authenticatable
         'name',
         'email',
         'username',
+        'image',
         'password',
     ];
 

--- a/database/factories/UserFactory.php
+++ b/database/factories/UserFactory.php
@@ -19,6 +19,7 @@ class UserFactory extends Factory
             'name' => $this->faker->name(),
             'email' => $this->faker->unique()->safeEmail(),
             'username' => $this->faker->unique()->userName(),
+            'image' => $this->faker->imageUrl(),
             'email_verified_at' => now(),
             'password' => 'password',
             'remember_token' => Str::random(10),

--- a/database/migrations/2025_09_27_000000_add_image_to_users_table.php
+++ b/database/migrations/2025_09_27_000000_add_image_to_users_table.php
@@ -1,0 +1,22 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    public function up(): void
+    {
+        Schema::table('users', function (Blueprint $table) {
+            $table->string('image')->nullable()->after('username');
+        });
+    }
+
+    public function down(): void
+    {
+        Schema::table('users', function (Blueprint $table) {
+            $table->dropColumn('image');
+        });
+    }
+};

--- a/routes/api.php
+++ b/routes/api.php
@@ -1,14 +1,20 @@
 <?php
 
 use App\Http\Controllers\Auth\AuthenticatedUserController;
+use App\Http\Controllers\Auth\LoginController;
+use App\Http\Controllers\Auth\LogoutController;
 use App\Http\Controllers\Auth\RegisterController;
+use App\Http\Controllers\Auth\UpdateAuthenticatedUserController;
 use App\Http\Controllers\ProductController;
 use Illuminate\Support\Facades\Route;
 
 Route::post('register', RegisterController::class);
+Route::post('login', LoginController::class);
 
 Route::middleware('auth:sanctum')->group(function () {
     Route::get('me', AuthenticatedUserController::class);
+    Route::put('me', UpdateAuthenticatedUserController::class);
+    Route::post('logout', LogoutController::class);
 
     Route::prefix('v1')->group(function () {
         Route::apiResource('products', ProductController::class);

--- a/tests/Feature/Auth/LoginTest.php
+++ b/tests/Feature/Auth/LoginTest.php
@@ -1,0 +1,44 @@
+<?php
+
+namespace Tests\Feature\Auth;
+
+use App\Models\User;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Illuminate\Support\Facades\Hash;
+use Tests\TestCase;
+
+class LoginTest extends TestCase
+{
+    use RefreshDatabase;
+
+    public function test_it_logs_in_with_valid_credentials(): void
+    {
+        $password = 'password123';
+
+        $user = User::factory()->create([
+            'password' => Hash::make($password),
+        ]);
+
+        $response = $this->postJson('/api/login', [
+            'email' => $user->email,
+            'password' => $password,
+        ]);
+
+        $response->assertOk();
+        $response->assertJsonPath('user.id', $user->id);
+        $response->assertJsonStructure(['user', 'token']);
+    }
+
+    public function test_it_fails_with_invalid_credentials(): void
+    {
+        $user = User::factory()->create();
+
+        $response = $this->postJson('/api/login', [
+            'email' => $user->email,
+            'password' => 'invalid-password',
+        ]);
+
+        $response->assertUnprocessable();
+        $response->assertJsonValidationErrors('email');
+    }
+}

--- a/tests/Feature/Auth/LoginTest.php
+++ b/tests/Feature/Auth/LoginTest.php
@@ -26,6 +26,7 @@ class LoginTest extends TestCase
 
         $response->assertOk();
         $response->assertJsonPath('user.id', $user->id);
+        $response->assertJsonPath('user.image', $user->image);
         $response->assertJsonStructure(['user', 'token']);
     }
 

--- a/tests/Feature/Auth/LogoutTest.php
+++ b/tests/Feature/Auth/LogoutTest.php
@@ -1,0 +1,31 @@
+<?php
+
+namespace Tests\Feature\Auth;
+
+use App\Models\User;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Tests\TestCase;
+
+class LogoutTest extends TestCase
+{
+    use RefreshDatabase;
+
+    public function test_it_revokes_the_current_token(): void
+    {
+        $user = User::factory()->create();
+        $token = $user->createToken('auth_token');
+
+        $response = $this->withToken($token->plainTextToken)->postJson('/api/logout');
+
+        $response->assertNoContent();
+
+        $this->assertDatabaseMissing('personal_access_tokens', [
+            'id' => $token->accessToken->id,
+        ]);
+    }
+
+    public function test_it_requires_authentication(): void
+    {
+        $this->postJson('/api/logout')->assertUnauthorized();
+    }
+}

--- a/tests/Feature/Auth/UpdateAuthenticatedUserTest.php
+++ b/tests/Feature/Auth/UpdateAuthenticatedUserTest.php
@@ -1,0 +1,94 @@
+<?php
+
+namespace Tests\Feature\Auth;
+
+use App\Models\User;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Illuminate\Support\Facades\Hash;
+use Laravel\Sanctum\Sanctum;
+use Tests\TestCase;
+
+class UpdateAuthenticatedUserTest extends TestCase
+{
+    use RefreshDatabase;
+
+    public function test_it_updates_the_email(): void
+    {
+        $user = User::factory()->create();
+
+        Sanctum::actingAs($user);
+
+        $response = $this->putJson('/api/me', [
+            'email' => 'new-email@example.com',
+        ]);
+
+        $response->assertOk();
+        $response->assertJsonPath('data.email', 'new-email@example.com');
+
+        $this->assertDatabaseHas('users', [
+            'id' => $user->id,
+            'email' => 'new-email@example.com',
+        ]);
+    }
+
+    public function test_it_updates_the_password(): void
+    {
+        $user = User::factory()->create();
+
+        Sanctum::actingAs($user);
+
+        $response = $this->putJson('/api/me', [
+            'password' => 'new-password123',
+            'password_confirmation' => 'new-password123',
+        ]);
+
+        $response->assertOk();
+
+        $user->refresh();
+
+        $this->assertTrue(Hash::check('new-password123', $user->password));
+    }
+
+    public function test_it_requires_unique_email(): void
+    {
+        $user = User::factory()->create();
+        $otherUser = User::factory()->create([
+            'email' => 'existing@example.com',
+        ]);
+
+        Sanctum::actingAs($user);
+
+        $response = $this->putJson('/api/me', [
+            'email' => $otherUser->email,
+        ]);
+
+        $response->assertUnprocessable();
+        $response->assertJsonValidationErrors('email');
+    }
+
+    public function test_it_does_not_allow_changing_the_name(): void
+    {
+        $user = User::factory()->create();
+
+        Sanctum::actingAs($user);
+
+        $response = $this->putJson('/api/me', [
+            'name' => 'New Name',
+        ]);
+
+        $response->assertUnprocessable();
+        $response->assertJsonValidationErrors('name');
+    }
+
+    public function test_it_requires_at_least_one_field(): void
+    {
+        $user = User::factory()->create();
+
+        Sanctum::actingAs($user);
+
+        $response = $this->putJson('/api/me', []);
+
+        $response->assertUnprocessable();
+        $response->assertJsonValidationErrors('email');
+    }
+}

--- a/tests/Feature/Auth/UpdateAuthenticatedUserTest.php
+++ b/tests/Feature/Auth/UpdateAuthenticatedUserTest.php
@@ -49,6 +49,27 @@ class UpdateAuthenticatedUserTest extends TestCase
         $this->assertTrue(Hash::check('new-password123', $user->password));
     }
 
+    public function test_it_updates_the_image(): void
+    {
+        $user = User::factory()->create([
+            'image' => 'https://example.com/old-image.png',
+        ]);
+
+        Sanctum::actingAs($user);
+
+        $response = $this->putJson('/api/me', [
+            'image' => 'https://example.com/new-image.png',
+        ]);
+
+        $response->assertOk();
+        $response->assertJsonPath('data.image', 'https://example.com/new-image.png');
+
+        $this->assertDatabaseHas('users', [
+            'id' => $user->id,
+            'image' => 'https://example.com/new-image.png',
+        ]);
+    }
+
     public function test_it_requires_unique_email(): void
     {
         $user = User::factory()->create();


### PR DESCRIPTION
## Summary
- add login and logout API endpoints backed by Sanctum tokens
- allow authenticated users to update their email or password while forbidding name changes
- cover the new authentication flows with feature tests

## Testing
- php artisan test *(fails: composer install requires GitHub token to fetch dependencies)*

------
https://chatgpt.com/codex/tasks/task_e_68d72b9ee15c832e9e7906bda4505098